### PR TITLE
Remove probes config

### DIFF
--- a/kamel-config.yaml
+++ b/kamel-config.yaml
@@ -1,6 +1,0 @@
-kamel:
-  run:
-    integration:
-      api:
-        # Enable probes by default on the API container
-        traits: '[container.probes-enabled=true]'


### PR DESCRIPTION
Let's try with this config. The smoke CI will trigger tests multiple times to see if it's flacky without probes.