### PR TITLE
fix knative check - use required oc client instead of kubectl

### DIFF
--- a/readme.didact.md
+++ b/readme.didact.md
@@ -83,7 +83,7 @@ access all Camel K features.
 
 The cluster also needs to have Knative installed and working. Refer to steps above for information on how to install it in your cluster.
 
-[Check if the Knative is installed](didact://?commandId=vscode.didact.requirementCheck&text=kservice-project-check$$kubectl%20api-resources%20--api-group=serving.knative.dev$$kservice%2Cksvc&completion=Verified%20Knative%20services%20installation. "Verifies if Knative is installed"){.didact}
+[Check if the Knative is installed](didact://?commandId=vscode.didact.requirementCheck&text=kservice-project-check$$oc%20api-resources%20--api-group=serving.knative.dev$$kservice%2Cksvc&completion=Verified%20Knative%20services%20installation. "Verifies if Knative is installed"){.didact}
 
 *Status: unknown*{#kservice-project-check}
 


### PR DESCRIPTION
The quickstart requires the user to install `oc`, therefore in case the `kubectl` isn't on the system prior to the quickstart, the knative check would always result to false.